### PR TITLE
Added Basic GitHub Discussions Functionality

### DIFF
--- a/commands/github-issue-number.js
+++ b/commands/github-issue-number.js
@@ -17,6 +17,9 @@ module.exports = {
                 const data = fs.writeFileSync("./github-issue-number.txt", issue);
             } catch (err) {
                 console.error(err);
+                return message.reply(
+                    "Your issue/PR number was not saved. Please try again."
+                );
             }
             return message.reply(
                 "to post a comment on issue " + issue + " , use -github-post-comment followed by your message."

--- a/commands/github-post-comment.js
+++ b/commands/github-post-comment.js
@@ -17,6 +17,7 @@ module.exports = {
                 return data;
             } catch (err) {
                 console.error(err);
+                return message.reply("Your GitHub Personal Access Token could not been read. Please set it again using -github-info.");
             }
         }
 
@@ -26,6 +27,7 @@ module.exports = {
                 return data;
             } catch (err) {
                 console.error(err);
+                return message.reply("Your issue/PR number could not be read. Please set it again using -github-issue-number.");
             }
         }
 
@@ -53,7 +55,10 @@ module.exports = {
                 .then((result) => {
                     return message.reply("Your comment: " + comment + " has been posted.");
                 })
-                .catch((error) => console.log(error));
+                .catch((error) => {
+                    console.log(error);
+                    return message.reply("Posting your comment was unsuccessful. Please ensure you have set your GitHub token using -github and an issue/PR number using -github-issue-number and then try again.");
+                });
         }
     },
 };

--- a/commands/github-post-standup.js
+++ b/commands/github-post-standup.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+
+module.exports = {
+    name: "github-post-standup",
+    description: "Post a comment on a GitHub discussion",
+    execute(command, message, args) {
+        // -github-post-comment: Posts desired comment on previously specified issue/PR
+        if (command === "github-post-standup") {
+            postComment(args);
+        }
+
+        function readToken() {
+            try {
+                const data = fs.readFileSync("./github-token.txt", "utf8");
+                return data;
+            } catch (err) {
+                console.error(err);
+                return message.reply(
+                    "Your GitHub Personal Access Token could not been read. Please set it again using -github-info."
+                );
+            }
+        }
+
+        // Post Comment function
+        async function postComment(args) {
+            // GitHub Variables
+            let githubToken = readToken();
+
+            // Intialise GitHub API
+            const { Octokit } = require("@octokit/core");
+            const { restEndpointMethods } = require("@octokit/plugin-rest-endpoint-methods");
+            const MyOctokit = Octokit.plugin(restEndpointMethods);
+            let octokit = new MyOctokit({ auth: githubToken });
+            console.log(args);
+            await octokit.rest.teams
+                .createDiscussionCommentInOrg({
+                    org: args[0],
+                    team_slug: args[1],
+                    discussion_number: args[2],
+                    body: args[3],
+                })
+                .then((result) => {
+                    return message.reply(
+                        "Your comment: " +
+                            args[3] +
+                            " has been posted on " +
+                            args[1] +
+                            " 's discussion # " +
+                            args[2] +
+                            " ."
+                    );
+                })
+                .catch((error) => {
+                    console.log(error);
+                    return message.reply(
+                        "Posting your comment was unsuccessful. Please ensure you have set your GitHub token using -github and entered the information in the correct order of organisation name, team name, discussion number and comment and then try again."
+                    );
+                });
+        }
+    },
+};

--- a/commands/github-post-standup.js
+++ b/commands/github-post-standup.js
@@ -41,13 +41,13 @@ module.exports = {
                 })
                 .then((result) => {
                     return message.reply(
-                        "Your comment: " +
+                        "Your comment '" +
                             args[3] +
-                            " has been posted on " +
+                            "' has been posted on " +
                             args[1] +
-                            " 's discussion # " +
+                            "'s discussion #" +
                             args[2] +
-                            " ."
+                            "."
                     );
                 })
                 .catch((error) => {

--- a/commands/github.info.js
+++ b/commands/github.info.js
@@ -12,6 +12,9 @@ module.exports = {
                 const data = fs.writeFileSync("./github-token.txt", githubToken);
             } catch (err) {
                 console.error(err);
+                return message.reply(
+                    "GitHub auth was unsuccessful. Please try again."
+                );
             }
         }
 

--- a/commands/help.js
+++ b/commands/help.js
@@ -23,7 +23,7 @@ module.exports = {
         if (!args.length) {
             data.push('Here\'s a list of all my commands:');
             data.push(listCommands.map(listCommand => listCommand.name).join(', '));
-            data.push(`\nYou can send \`-help [command name]\` to get info on a specific command!`);
+            data.push("\nYou can send \-help [command name]\ to get info on a specific command!");
 
             return message.reply(data, { split: true })
                 .then(() => {
@@ -49,10 +49,10 @@ module.exports = {
             return message.reply('that\'s not a valid command!');
         }
 
-        data.push(`**Name:** ${listCommand.name}`);
+        data.push("**Name:** ${listCommand.name}");
 
         //if (command.aliases) data.push(`**Aliases:** ${command.aliases.join(', ')}`);
-        if (listCommand.description) data.push(`**Description:** ${listCommand.description}`);
+        if (listCommand.description) data.push("**Description:** ${listCommand.description}");
         //if (command.usage) data.push(`**Usage:** ${prefix}${command.name} ${command.usage}`);
 
         //data.push(`**Cooldown:** ${command.cooldown || 3} second(s)`);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@octokit/plugin-rest-endpoint-methods": "^5.5.2",
     "discord.js": "^12.5.3",
     "fs": "^0.0.1-security",
-    "octokit": "^1.1.0",
+    "octokit": "^1.1.0"
   },
   "devDependencies": {
     "dotenv": "^10.0.0"


### PR DESCRIPTION
### Features

- Added a new file `github-post-standup.js` with the respective bot command for posting comments to GitHub Discussions (Stand-up Mode)

- Works with multiple arguments so the entire comment posting functionality (org, team, discussion number and comment) can be posted in one command - Helps #25.

- Improved bot replies (messages)

- Added error message replies to the bot

- Fixed package.json syntax error

This solves #24.

### Improvements

- Implement multiple args for normal comments - to solve #22.

- Add edit and reply functionality (probably separate files) for Discussions - to close #24
