### PR TITLE
Fixed `-help github-info` command 

### DIFF
--- a/commands/github-info.js
+++ b/commands/github-info.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+
+module.exports = {
+    name: "github-info",
+    description: "Get GitHub Personal Access Token",
+    execute(command, message, args) {
+        let githubToken = null;
+
+        function writeToken(githubToken) {
+            try {
+                console.log("GitHub token is " + githubToken);
+                const data = fs.writeFileSync("./github-token.txt", githubToken);
+            } catch (err) {
+                console.error(err);
+                return message.reply(
+                    "GitHub auth was unsuccessful. Please try again."
+                );
+            }
+        }
+
+        // -github-info: Get contents of personal token
+        if (command === "github-info") {
+            if (!args.length) {
+                return message.reply("you didn't provide a GitHub Personal Token.");
+            } else {
+                githubToken = args[0];
+                writeToken(githubToken);
+                return message.reply(
+                    "GitHub auth was successful. Use -github-issue-number with the number of the issue you'd like to comment on."
+                );
+            }
+        }
+    },
+};


### PR DESCRIPTION
### Why This PR Adds Value

This PR fixes the'-help github-info` command. Earlier, the bot would stop working on running this command, as we changed the help command to work dynamically. 

### What This PR Adds

- the file 'commands/github.info.js` is changed to 'commands/github-info.js`.

This closes #41 
