### PR TITLE
Added GitHub Discussion Update Comment Functionality

### DIFF
--- a/commands/github-update-standup.js
+++ b/commands/github-update-standup.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+
+module.exports = {
+    name: "github-update-standup",
+    description: "Update a comment on a GitHub discussion",
+    execute(command, message, args) {
+        // -github-post-standup: Posts desired comment on a GitHub Discussion
+        if (command === "github-update-standup") {
+            comment = args.slice(4);
+            comment = comment.join(" ");
+            readToken();
+            postComment(comment, args);
+        }
+
+        function readToken() {
+            try {
+                const data = fs.readFileSync("./github-token.txt", "utf8");
+                return data;
+            } catch (err) {
+                console.error(err);
+                return message.reply(
+                    "Your GitHub Personal Access Token could not been read. Please set it again using -github-info."
+                );
+            }
+        }
+
+        // Post Comment function
+        async function postComment(comment) {
+            // GitHub Variables
+            let githubToken = readToken();
+
+            // Intialise GitHub API
+            const { Octokit } = require("@octokit/core");
+            const { restEndpointMethods } = require("@octokit/plugin-rest-endpoint-methods");
+            const MyOctokit = Octokit.plugin(restEndpointMethods);
+            let octokit = new MyOctokit({ auth: githubToken });
+
+            // Post Discussion Comment
+            await octokit.rest.teams
+                .updateDiscussionCommentInOrg({
+                    org: args[0],
+                    team_slug: args[1],
+                    discussion_number: args[2],
+                    comment_number: args[3],
+                    body: comment,
+                })
+                .then((result) => {
+                    return message.reply(
+                        "Your comment '" +
+                            comment +
+                            "' has been updated on " +
+                            args[1] +
+                            "'s discussion #" +
+                            args[2] +
+                            "."
+                    );
+                })
+                .catch((error) => {
+                    console.log(error);
+                    return message.reply(
+                        "Updating your comment was unsuccessful. Please ensure you have set your GitHub token using -github and entered the information in the correct order of organisation name, team name, discussion number, comment number and comment and then try again."
+                    );
+                });
+        }
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "pod-3.1.3-team-4",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -2563,6 +2563,15 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "dev": true
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2906,6 +2915,36 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -2921,6 +2960,17 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
         "semver": "^5.6.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "jwa": {
@@ -3053,6 +3103,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "octokit": {
       "version": "1.1.0",
@@ -3291,6 +3346,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.7.1",


### PR DESCRIPTION
### Why This PR Adds Value

Added functionality to be able to update GitHub Discussion comments. This is valuable because often pod members will post their standup notes early (so they are not in a rush just before standup) and update them as work is accomplished.

### What This PR Adds

- Added `github-update-standup.js` file in the `commands` folder

### Screenshot

![Discord Standup Update](https://user-images.githubusercontent.com/26024131/128074527-fd597317-981a-46db-9e84-cb2d64c8ec2d.png)

### How This PR Could Be Improved

- **Listing Comments** - This PR could be improved by being able to list all the comments (along with comment numbers) so users can easily pick out the comment number they wish to update - #25 

- **Persistence** - This PR could also be improved by being able to store info from `-github-post-comment` to be reused when updating a comment

### Issue This PR Closes

This closes #24.